### PR TITLE
feat: add local embedding mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ It is built on a modular design and currently supports the following components:
 * **ValidateSQLAgent:** An agent that validates the syntax and semantic correctness of SQL queries. It uses a language model to analyze queries against a database schema and returns a JSON response indicating validity and potential errors.
 * **DebugSQLAgent:** An agent designed to debug and refine SQL queries for BigQuery or PostgreSQL databases. It interacts with a chat-based language model to iteratively troubleshoot queries, using error messages to generate alternative, correct queries.
 * **DescriptionAgent:** An agent specialized in generating descriptions for database tables and columns. It leverages a large language model to create concise and informative descriptions that aid in understanding data structures and facilitate SQL query generation.
-* **EmbedderAgent:** An agent specialized in generating text embeddings using Large Language Models (LLMs). It supports direct interaction with Vertex AI's TextEmbeddingModel or uses LangChain's VertexAIEmbeddings for a simplified interface.
+* **EmbedderAgent:** An agent specialized in generating text embeddings using Large Language Models (LLMs). It supports direct interaction with Vertex AI's TextEmbeddingModel, uses LangChain's VertexAIEmbeddings for a simplified interface, or loads local models via `sentence-transformers`.
 * **ResponseAgent:** An agent that generates natural language responses to user questions based on SQL query results. It acts as a data assistant, interpreting SQL results and transforming them into user-friendly answers using a language model.
 * **VisualizeAgent:** An agent that generates JavaScript code for Google Charts based on user questions and SQL results. It suggests suitable chart types and constructs the JavaScript code to create visualizations of the data.
 
@@ -192,6 +192,25 @@ ___________
 For setup we require details for vector store, source database etc. Edit the [config.ini](/config.ini) file and add values for the parameters based of below information.
 
 ℹ️ Follow the guidelines from the [config guide document](/docs/config_guide.md) to populate your [config.ini](/config.ini) file.
+
+**Using a local embedding model**
+
+1. Install the `sentence-transformers` library if it is not already available.
+2. Download and save a model. For example:
+
+   ```python
+   from sentence_transformers import SentenceTransformer
+   SentenceTransformer('all-MiniLM-L6-v2').save('/path/to/model')
+   ```
+
+3. Update `config.ini`:
+
+   ```ini
+   embedding_model = local
+   embedding_model_path = /path/to/model
+   ```
+
+The path should point to the directory containing the model weights.
 
 **Sources to connect**
 

--- a/config.ini
+++ b/config.ini
@@ -1,5 +1,6 @@
 [CONFIG]
 embedding_model = vertex
+embedding_model_path = 
 description_model = gemini-1.5-pro
 vector_store = bigquery-vector
 debugging = yes

--- a/docs/config_guide.md
+++ b/docs/config_guide.md
@@ -4,7 +4,10 @@ ______________
 
 **[CONFIG]**
 
-**embedding_model = vertex**     *;Options: 'vertex' or 'vertex-lang'*
+**embedding_model = vertex**     *;Options: 'vertex', 'vertex-lang', or 'local'*
+
+**embedding_model_path = /path/to/model** *;Required when `embedding_model` is 'local'. Path to a
+locally downloaded `sentence-transformers` model*
 
 **description_model = gemini-1.0-pro**   *;Options 'gemini-1.0-pro', 'gemini-1.5-pro', 'text-bison-32k', 'gemini-1.5-flash'*
 

--- a/embeddings/kgq_embeddings.py
+++ b/embeddings/kgq_embeddings.py
@@ -5,14 +5,28 @@ import pandas as pd
 import numpy as np
 from pgvector.asyncpg import register_vector
 from google.cloud.sql.connector import Connector
-from langchain_community.embeddings import VertexAIEmbeddings
 from google.cloud import bigquery
 from dbconnectors import pgconnector
 from agents import EmbedderAgent
 from sqlalchemy.sql import text
-from utilities import PROJECT_ID, PG_INSTANCE, PG_DATABASE, PG_USER, PG_PASSWORD, PG_REGION, BQ_OPENDATAQNA_DATASET_NAME, BQ_REGION
+from utilities import (
+    PROJECT_ID,
+    PG_INSTANCE,
+    PG_DATABASE,
+    PG_USER,
+    PG_PASSWORD,
+    PG_REGION,
+    BQ_OPENDATAQNA_DATASET_NAME,
+    BQ_REGION,
+    EMBEDDING_MODEL,
+    EMBEDDING_MODEL_PATH,
+)
 
-embedder = EmbedderAgent('vertex')
+
+if EMBEDDING_MODEL == "local":
+    embedder = EmbedderAgent("local", EMBEDDING_MODEL_PATH)
+else:
+    embedder = EmbedderAgent(EMBEDDING_MODEL)
 
 
 async def setup_kgq_table( project_id,

--- a/embeddings/retrieve_embeddings.py
+++ b/embeddings/retrieve_embeddings.py
@@ -1,12 +1,21 @@
 import re
 import io
-import sys 
+import sys
 import pandas as pd
-from dbconnectors import pgconnector,bqconnector
+from dbconnectors import pgconnector, bqconnector
 from agents import EmbedderAgent, ResponseAgent, DescriptionAgent
-from utilities import EMBEDDING_MODEL, DESCRIPTION_MODEL, USE_COLUMN_SAMPLES
+from utilities import (
+    EMBEDDING_MODEL,
+    EMBEDDING_MODEL_PATH,
+    DESCRIPTION_MODEL,
+    USE_COLUMN_SAMPLES,
+)
 
-embedder = EmbedderAgent(EMBEDDING_MODEL)
+
+if EMBEDDING_MODEL == "local":
+    embedder = EmbedderAgent("local", EMBEDDING_MODEL_PATH)
+else:
+    embedder = EmbedderAgent(EMBEDDING_MODEL)
 # responder = ResponseAgent('gemini-1.0-pro')
 descriptor = DescriptionAgent(DESCRIPTION_MODEL)
 

--- a/embeddings/store_embeddings.py
+++ b/embeddings/store_embeddings.py
@@ -4,14 +4,29 @@ import pandas as pd
 import numpy as np
 from pgvector.asyncpg import register_vector
 from google.cloud.sql.connector import Connector
-from langchain_community.embeddings import VertexAIEmbeddings
 from google.cloud import bigquery
 from dbconnectors import pgconnector
 from agents import EmbedderAgent
 from sqlalchemy.sql import text
-from utilities import VECTOR_STORE, PROJECT_ID, PG_INSTANCE, PG_DATABASE, PG_USER, PG_PASSWORD, PG_REGION, BQ_OPENDATAQNA_DATASET_NAME, BQ_REGION, EMBEDDING_MODEL
+from utilities import (
+    VECTOR_STORE,
+    PROJECT_ID,
+    PG_INSTANCE,
+    PG_DATABASE,
+    PG_USER,
+    PG_PASSWORD,
+    PG_REGION,
+    BQ_OPENDATAQNA_DATASET_NAME,
+    BQ_REGION,
+    EMBEDDING_MODEL,
+    EMBEDDING_MODEL_PATH,
+)
 
-embedder = EmbedderAgent(EMBEDDING_MODEL)
+
+if EMBEDDING_MODEL == "local":
+    embedder = EmbedderAgent("local", EMBEDDING_MODEL_PATH)
+else:
+    embedder = EmbedderAgent(EMBEDDING_MODEL)
 
 async def store_schema_embeddings(table_details_embeddings, 
                             tablecolumn_details_embeddings, 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ flask-cors = "^4.0.0"
 Werkzeug = "^2.3.7"
 google-cloud-firestore= "^2.16.0"
 firebase-admin = "^5.2.0"
+sentence-transformers = "^2.6.1"
 
 
 

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -51,6 +51,8 @@ def format_prompt(context_prompt, **kwargs):
 
 # [CONFIG]
 EMBEDDING_MODEL = config['CONFIG']['EMBEDDING_MODEL']
+# Optional path for locally hosted embedding models
+EMBEDDING_MODEL_PATH = config['CONFIG'].get('EMBEDDING_MODEL_PATH', '')
 DESCRIPTION_MODEL = config['CONFIG']['DESCRIPTION_MODEL']
 # DATA_SOURCE = config['CONFIG']['DATA_SOURCE'] 
 VECTOR_STORE = config['CONFIG']['VECTOR_STORE']
@@ -86,27 +88,30 @@ FIRESTORE_REGION = config['CONFIG']['FIRESTORE_REGION']
 #[PROMPTS]
 PROMPTS = load_yaml(root_dir + '/prompts.yaml')
 
-__all__ = ["EMBEDDING_MODEL",
-           "DESCRIPTION_MODEL",
-          #"DATA_SOURCE",
-           "VECTOR_STORE",
-           #"CACHING",
-           #"DEBUGGING",
-           "LOGGING",
-           "EXAMPLES", 
-           "PROJECT_ID",
-           "PG_REGION",
-        #    "PG_SCHEMA",
-           "PG_INSTANCE",
-           "PG_DATABASE",
-           "PG_USER",
-           "PG_PASSWORD", 
-           "BQ_REGION",
-        #    "BQ_DATASET_NAME",
-           "BQ_OPENDATAQNA_DATASET_NAME",
-           "BQ_LOG_TABLE_NAME",
-        #    "BQ_TABLE_LIST",
-           "FIRESTORE_REGION",
-           "PROMPTS"
-           "root_dir",
-           "save_config"]
+__all__ = [
+    "EMBEDDING_MODEL",
+    "EMBEDDING_MODEL_PATH",
+    "DESCRIPTION_MODEL",
+    # "DATA_SOURCE",
+    "VECTOR_STORE",
+    # "CACHING",
+    # "DEBUGGING",
+    "LOGGING",
+    "EXAMPLES",
+    "PROJECT_ID",
+    "PG_REGION",
+    # "PG_SCHEMA",
+    "PG_INSTANCE",
+    "PG_DATABASE",
+    "PG_USER",
+    "PG_PASSWORD",
+    "BQ_REGION",
+    # "BQ_DATASET_NAME",
+    "BQ_OPENDATAQNA_DATASET_NAME",
+    "BQ_LOG_TABLE_NAME",
+    # "BQ_TABLE_LIST",
+    "FIRESTORE_REGION",
+    "PROMPTS",
+    "root_dir",
+    "save_config",
+]


### PR DESCRIPTION
## Summary
- add `local` embedding mode powered by `sentence-transformers`
- allow embedding scripts to load either Vertex AI or local models based on config
- document how to download local model weights and configure their path

## Testing
- `python -m py_compile agents/EmbedderAgent.py embeddings/kgq_embeddings.py embeddings/store_embeddings.py embeddings/retrieve_embeddings.py utilities/__init__.py`
- `pytest -q`
- `pip install sentence-transformers >/tmp/pip.log && tail -n 20 /tmp/pip.log`


------
https://chatgpt.com/codex/tasks/task_e_68ae6e96e820832db330b7a37ddc24ea