### PR TITLE
feat: add local mode configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ It is built on a modular design and currently supports the following components:
 ### Database Connectors
 * **Google Cloud SQL for PostgreSQL**
 * **Google BigQuery**
-* **Google Firestore(for storing session logs)**
+* **Google Firestore (for storing session logs)**
+* **Local PostgreSQL/SQLite connectors for offline development**
 
 ### Vector Stores 
 * **PGVector on Google Cloud SQL for PostgreSQL**

--- a/config.ini
+++ b/config.ini
@@ -1,4 +1,5 @@
 [CONFIG]
+mode = gcp
 embedding_model = vertex
 description_model = gemini-1.5-pro
 vector_store = bigquery-vector
@@ -23,6 +24,11 @@ pg_password = pg123
 bq_dataset_region = us-central1
 bq_opendataqna_dataset_name = opendataqna
 bq_log_table_name = audit_log_table
+
+[LOCAL]
+pg_conn_string = postgresql://pguser:pg123@localhost:5432/opendataqna-db
+embedding_model_path = ./models/all-MiniLM-L6-v2
+llm_endpoint = http://localhost:8000/v1
 
 
 

--- a/config.ini
+++ b/config.ini
@@ -9,6 +9,7 @@ kgq_examples = yes
 firestore_region = us-central1
 use_session_history = yes
 use_column_samples = no
+connector_backend = local
 
 [GCP]
 project_id = three-p-o
@@ -29,7 +30,5 @@ bq_log_table_name = audit_log_table
 pg_conn_string = postgresql://pguser:pg123@localhost:5432/opendataqna-db
 embedding_model_path = ./models/all-MiniLM-L6-v2
 llm_endpoint = http://localhost:8000/v1
-
-
-
-
+pg_conn = postgresql+psycopg2://user:pass@localhost:5432/opendataqna
+sqlite_db = opendataqna.db

--- a/config.local.ini
+++ b/config.local.ini
@@ -1,0 +1,16 @@
+[CONFIG]
+mode = local
+embedding_model = ./models/all-MiniLM-L6-v2
+description_model = http://localhost:8000/v1/models/gpt
+vector_store = pgvector
+debugging = yes
+logging = yes
+kgq_examples = yes
+firestore_region = us-central1
+use_session_history = yes
+use_column_samples = no
+
+[LOCAL]
+pg_conn_string = postgresql://pguser:pg123@localhost:5432/opendataqna-db
+embedding_model_path = ./models/all-MiniLM-L6-v2
+llm_endpoint = http://localhost:8000/v1/models/gpt

--- a/dbconnectors/LocalBQConnector.py
+++ b/dbconnectors/LocalBQConnector.py
@@ -1,0 +1,83 @@
+"""Local BigQuery-like connector using SQLite.
+
+The original :mod:`dbconnectors.BQConnector` relies on the Google Cloud
+BigQuery client.  For local development and testing we provide a
+minimal implementation backed by SQLite.  It supports the small subset
+of functionality used by the application – executing SQL and returning
+results as :class:`pandas.DataFrame` objects and recording audit
+information.
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+import sqlite3
+from datetime import datetime
+
+import pandas as pd
+
+from .core import DBConnector
+
+
+class LocalBQConnector(DBConnector, ABC):
+    """Connector that executes SQL against a local SQLite database."""
+
+    def __init__(self, db_path: str, audit_table: str = "audit_log"):
+        self.db_path = db_path
+        self.audit_table = audit_table
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._ensure_audit_table()
+
+    def _ensure_audit_table(self) -> None:
+        with self.conn:
+            self.conn.execute(
+                f"""CREATE TABLE IF NOT EXISTS {self.audit_table} (
+                    source_type TEXT,
+                    user_grouping TEXT,
+                    model_used TEXT,
+                    question TEXT,
+                    generated_sql TEXT,
+                    execution_time TEXT,
+                    full_log TEXT
+                )"""
+            )
+
+    def getconn(self):
+        return self.conn
+
+    def retrieve_df(self, query: str) -> pd.DataFrame:
+        return pd.read_sql_query(query, self.conn)
+
+    def make_audit_entry(
+        self,
+        source_type: str,
+        user_grouping: str,
+        model: str,
+        question: str,
+        generated_sql: str,
+        found_in_vector: bool,
+        need_rewrite: bool,
+        failure_step: str,
+        error_msg: str,
+        full_log_text: str,
+    ) -> str:
+        """Persist a minimal audit record to the local SQLite DB."""
+
+        with self.conn:
+            self.conn.execute(
+                f"INSERT INTO {self.audit_table} VALUES (?,?,?,?,?,?,?)",
+                (
+                    source_type,
+                    user_grouping,
+                    model,
+                    question,
+                    generated_sql,
+                    datetime.utcnow().isoformat(),
+                    full_log_text,
+                ),
+            )
+        return "OK"
+
+
+__all__ = ["LocalBQConnector"]
+

--- a/dbconnectors/LocalFirestoreConnector.py
+++ b/dbconnectors/LocalFirestoreConnector.py
@@ -1,0 +1,69 @@
+"""Local Firestore replacement using SQLite.
+
+This connector stores session logs in a SQLite database allowing the
+application to run without access to Google Cloud Firestore.  The API
+mirrors the subset of functionality used by the rest of the code base.
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+import sqlite3
+
+from .core import DBConnector
+
+
+class LocalFirestoreConnector(DBConnector, ABC):
+    """Persist chat logs to a local SQLite table."""
+
+    def __init__(self, db_path: str):
+        self.conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._ensure_tables()
+
+    def _ensure_tables(self) -> None:
+        with self.conn:
+            self.conn.execute(
+                """CREATE TABLE IF NOT EXISTS session_logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT,
+                user_id TEXT,
+                user_question TEXT,
+                bot_response TEXT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )"""
+            )
+
+    def log_chat(
+        self,
+        session_id: str,
+        user_question: str,
+        bot_response: str,
+        user_id: str = "TEST",
+    ) -> None:
+        with self.conn:
+            self.conn.execute(
+                "INSERT INTO session_logs (session_id, user_id, user_question, bot_response)"
+                " VALUES (?, ?, ?, ?)",
+                (session_id, user_id, user_question, bot_response),
+            )
+
+    def get_chat_logs_for_session(self, session_id: str):
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT user_question, bot_response, timestamp FROM session_logs"
+            " WHERE session_id=? ORDER BY timestamp",
+            (session_id,),
+        )
+        rows = cur.fetchall()
+        return [
+            {
+                "user_question": r[0],
+                "bot_response": r[1],
+                "timestamp": r[2],
+            }
+            for r in rows
+        ]
+
+
+__all__ = ["LocalFirestoreConnector"]
+

--- a/dbconnectors/LocalPgConnector.py
+++ b/dbconnectors/LocalPgConnector.py
@@ -1,0 +1,47 @@
+"""Local PostgreSQL connector.
+
+This module provides a lightweight connector implementation that uses
+``sqlalchemy`` and ``psycopg2`` to talk to a locally running PostgreSQL
+instance.  It mirrors the :class:`PgConnector` interface used for the
+cloud implementation but avoids any dependency on Google Cloud specific
+libraries so that the application can be executed completely offline.
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+
+import pandas as pd
+from sqlalchemy import create_engine, text
+
+from .core import DBConnector
+
+
+class LocalPgConnector(DBConnector, ABC):
+    """Connector for a local PostgreSQL database.
+
+    Parameters
+    ----------
+    conn_str:
+        SQLAlchemy style connection string (e.g.
+        ``postgresql+psycopg2://user:pass@localhost/db``).
+    """
+
+    def __init__(self, conn_str: str):
+        self.conn_str = conn_str
+        self.engine = create_engine(conn_str)
+
+    def getconn(self):
+        """Return a new connection object."""
+
+        return self.engine.connect()
+
+    def retrieve_df(self, query: str) -> pd.DataFrame:
+        """Execute *query* and return the result as a :class:`DataFrame`."""
+
+        with self.getconn() as conn:
+            return pd.read_sql_query(text(query), conn)
+
+
+__all__ = ["LocalPgConnector"]
+

--- a/dbconnectors/__init__.py
+++ b/dbconnectors/__init__.py
@@ -1,13 +1,65 @@
-from .core import DBConnector
+"""Database connector factory.
+
+The project can operate either against Google Cloud services or against
+local databases for offline development.  This module exposes helper
+functions that return the appropriate connector instances based on the
+configuration loaded in :mod:`utilities`.
+"""
+
+from __future__ import annotations
+
+from .core import DBConnector  # re-export for convenience
 from .PgConnector import PgConnector, pg_specific_data_types
 from .BQConnector import BQConnector, bq_specific_data_types
 from .FirestoreConnector import FirestoreConnector
-from utilities import (PROJECT_ID, 
-                       PG_INSTANCE, PG_DATABASE, PG_USER, PG_PASSWORD, PG_REGION,BQ_REGION,
-                       BQ_OPENDATAQNA_DATASET_NAME,BQ_LOG_TABLE_NAME)
+from .LocalPgConnector import LocalPgConnector
+from .LocalBQConnector import LocalBQConnector
+from .LocalFirestoreConnector import LocalFirestoreConnector
 
-pgconnector = PgConnector(PROJECT_ID, PG_REGION, PG_INSTANCE, PG_DATABASE, PG_USER, PG_PASSWORD)
-bqconnector = BQConnector(PROJECT_ID,BQ_REGION,BQ_OPENDATAQNA_DATASET_NAME,BQ_LOG_TABLE_NAME)
-firestoreconnector = FirestoreConnector(PROJECT_ID,"opendataqna-session-logs")
+from utilities import (
+    PROJECT_ID,
+    PG_INSTANCE,
+    PG_DATABASE,
+    PG_USER,
+    PG_PASSWORD,
+    PG_REGION,
+    BQ_REGION,
+    BQ_OPENDATAQNA_DATASET_NAME,
+    BQ_LOG_TABLE_NAME,
+    CONNECTOR_BACKEND,
+    LOCAL_PG_CONN,
+    LOCAL_SQLITE_DB,
+)
 
-__all__ = ["pgconnector", "pg_specific_data_types", "bqconnector","firestoreconnector"]
+
+def get_pg_connector() -> DBConnector:
+    if CONNECTOR_BACKEND.lower() == "local":
+        return LocalPgConnector(LOCAL_PG_CONN)
+    return PgConnector(PROJECT_ID, PG_REGION, PG_INSTANCE, PG_DATABASE, PG_USER, PG_PASSWORD)
+
+
+def get_bq_connector() -> DBConnector:
+    if CONNECTOR_BACKEND.lower() == "local":
+        return LocalBQConnector(LOCAL_SQLITE_DB)
+    return BQConnector(PROJECT_ID, BQ_REGION, BQ_OPENDATAQNA_DATASET_NAME, BQ_LOG_TABLE_NAME)
+
+
+def get_firestore_connector() -> DBConnector:
+    if CONNECTOR_BACKEND.lower() == "local":
+        return LocalFirestoreConnector(LOCAL_SQLITE_DB)
+    return FirestoreConnector(PROJECT_ID, "opendataqna-session-logs")
+
+
+pgconnector = get_pg_connector()
+bqconnector = get_bq_connector()
+firestoreconnector = get_firestore_connector()
+
+__all__ = [
+    "DBConnector",
+    "pgconnector",
+    "pg_specific_data_types",
+    "bqconnector",
+    "bq_specific_data_types",
+    "firestoreconnector",
+]
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This directory contains documentation and resources to help you understand and u
 * **best_practices.md:** Best practices and guidelines for using the library, including recommended configurations, tips for improving performance, and common pitfalls to avoid.
 * **faq.md:** Frequently asked questions about the library, covering common issues, troubleshooting tips, and general usage guidance.
 * **repo_structure.md:** A detailed explanation of the library's repository structure, including the purpose of each file and directory, and how to navigate the codebase.
+* **local_setup.md:** Instructions for configuring and running the application with local PostgreSQL or SQLite databases instead of Google Cloud services.
 
 
 ## How to Use This Documentation

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -1,0 +1,35 @@
+# Running with local databases
+
+The project normally connects to Google Cloud services.  For offline
+development you can switch to lightweight local connectors that use
+standard database drivers.
+
+## Configure
+
+Edit `config.ini` and set the connector backend to `local` and provide
+connection information for the local databases:
+
+```ini
+[CONFIG]
+connector_backend = local
+
+[LOCAL]
+# PostgreSQL connection string
+pg_conn = postgresql+psycopg2://user:pass@localhost:5432/opendataqna
+# SQLite database used for the BigQuery and Firestore connectors
+sqlite_db = opendataqna.db
+```
+
+The SQLite file will be created automatically if it does not exist.
+
+## Launch
+
+After the configuration is updated, launch the application as usual:
+
+```bash
+python app.py
+```
+
+The application will now use the local PostgreSQL instance and the
+SQLite file instead of Google Cloud services.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ cloud-sql-python-connector = {extras = ["asyncpg"], version = "^1.7.0"}
 sqlalchemy = "^2.0.27"
 pgvector = "^0.2.5"
 pg8000 = "^1.30.5"
+psycopg2-binary = "^2.9.9"
 tabulate = "^0.9.0"
 langchain = "^0.1.9"
 fsspec = "^2024.2.0"

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -5,9 +5,10 @@ import yaml
 
 config = configparser.ConfigParser()
 
+
 def is_root_dir():
     """
-    Checks if the current working directory is the root directory of a project 
+    Checks if the current working directory is the root directory of a project
     by looking for either the "/notebooks" or "/agents" folders.
 
     Returns:
@@ -18,12 +19,14 @@ def is_root_dir():
     print("current dir: ", current_dir)
     notebooks_path = os.path.join(current_dir, "notebooks")
     agents_path = os.path.join(current_dir, "agents")
-    
+
     return os.path.exists(notebooks_path) or os.path.exists(agents_path)
+
 
 def load_yaml(file_path: str) -> dict:
     with open(file_path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
+
 
 if is_root_dir():
     current_dir = os.getcwd()
@@ -31,12 +34,13 @@ if is_root_dir():
     root_dir = current_dir
 else:
     root_dir = os.path.abspath(os.path.join(os.getcwd(), '..'))
-    config.read(root_dir+'/config.ini')
+    config.read(root_dir + '/config.ini')
 
-if not 'root_dir' in locals():  # If not found in any parent dir
+if 'root_dir' not in locals():  # If not found in any parent dir
     raise FileNotFoundError("config.ini not found in current or parent directories.")
 
 print(f'root_dir set to: {root_dir}')
+
 
 def format_prompt(context_prompt, **kwargs):
     """
@@ -49,64 +53,65 @@ def format_prompt(context_prompt, **kwargs):
     """
     return context_prompt.format(**kwargs)
 
-# [CONFIG]
-EMBEDDING_MODEL = config['CONFIG']['EMBEDDING_MODEL']
-DESCRIPTION_MODEL = config['CONFIG']['DESCRIPTION_MODEL']
-# DATA_SOURCE = config['CONFIG']['DATA_SOURCE'] 
-VECTOR_STORE = config['CONFIG']['VECTOR_STORE']
 
-#CACHING = config.getboolean('CONFIG','CACHING')
-#DEBUGGING = config.getboolean('CONFIG','DEBUGGING')
-LOGGING = config.getboolean('CONFIG','LOGGING')
+# [CONFIG]
+MODE = config['CONFIG'].get('MODE', 'gcp').lower()
+
+LOGGING = config.getboolean('CONFIG', 'LOGGING')
 EXAMPLES = config.getboolean('CONFIG', 'KGQ_EXAMPLES')
 USE_SESSION_HISTORY = config.getboolean('CONFIG', 'USE_SESSION_HISTORY')
-USE_COLUMN_SAMPLES = config.getboolean('CONFIG','USE_COLUMN_SAMPLES')
+USE_COLUMN_SAMPLES = config.getboolean('CONFIG', 'USE_COLUMN_SAMPLES')
+FIRESTORE_REGION = config['CONFIG'].get('FIRESTORE_REGION', '')
 
-#[GCP]
-PROJECT_ID =  config['GCP']['PROJECT_ID']
+VECTOR_STORE = config['CONFIG'].get('VECTOR_STORE')
+EMBEDDING_MODEL = None
+DESCRIPTION_MODEL = None
 
-#[PGCLOUDSQL]
-PG_REGION = config['PGCLOUDSQL']['PG_REGION']
-# PG_SCHEMA = config['PGCLOUDSQL']['PG_SCHEMA'] 
-PG_INSTANCE = config['PGCLOUDSQL']['PG_INSTANCE']
-PG_DATABASE = config['PGCLOUDSQL']['PG_DATABASE'] 
-PG_USER = config['PGCLOUDSQL']['PG_USER'] 
-PG_PASSWORD = config['PGCLOUDSQL']['PG_PASSWORD']
+PROJECT_ID = PG_REGION = PG_INSTANCE = PG_DATABASE = PG_USER = PG_PASSWORD = None
+BQ_REGION = BQ_OPENDATAQNA_DATASET_NAME = BQ_LOG_TABLE_NAME = None
+PG_CONN_STRING = None
 
-#[BIGQUERY]
-BQ_REGION = config['BIGQUERY']['BQ_DATASET_REGION']
-# BQ_DATASET_NAME = config['BIGQUERY']['BQ_DATASET_NAME']
-BQ_OPENDATAQNA_DATASET_NAME = config['BIGQUERY']['BQ_OPENDATAQNA_DATASET_NAME']
-BQ_LOG_TABLE_NAME = config['BIGQUERY']['BQ_LOG_TABLE_NAME']
-# BQ_TABLE_LIST = config['BIGQUERY']['BQ_TABLE_LIST']
+if MODE == 'gcp':
+    EMBEDDING_MODEL = config['CONFIG']['EMBEDDING_MODEL']
+    DESCRIPTION_MODEL = config['CONFIG']['DESCRIPTION_MODEL']
+    PROJECT_ID = config['GCP']['PROJECT_ID']
+    PG_REGION = config['PGCLOUDSQL']['PG_REGION']
+    PG_INSTANCE = config['PGCLOUDSQL']['PG_INSTANCE']
+    PG_DATABASE = config['PGCLOUDSQL']['PG_DATABASE']
+    PG_USER = config['PGCLOUDSQL']['PG_USER']
+    PG_PASSWORD = config['PGCLOUDSQL']['PG_PASSWORD']
+    BQ_REGION = config['BIGQUERY']['BQ_DATASET_REGION']
+    BQ_OPENDATAQNA_DATASET_NAME = config['BIGQUERY']['BQ_OPENDATAQNA_DATASET_NAME']
+    BQ_LOG_TABLE_NAME = config['BIGQUERY']['BQ_LOG_TABLE_NAME']
+elif MODE == 'local':
+    PG_CONN_STRING = config['LOCAL']['PG_CONN_STRING']
+    EMBEDDING_MODEL = config['LOCAL']['EMBEDDING_MODEL_PATH']
+    DESCRIPTION_MODEL = config['LOCAL']['LLM_ENDPOINT']
 
-#[FIRESTORE]
-FIRESTORE_REGION = config['CONFIG']['FIRESTORE_REGION']
-
-#[PROMPTS]
+# [PROMPTS]
 PROMPTS = load_yaml(root_dir + '/prompts.yaml')
 
-__all__ = ["EMBEDDING_MODEL",
-           "DESCRIPTION_MODEL",
-          #"DATA_SOURCE",
-           "VECTOR_STORE",
-           #"CACHING",
-           #"DEBUGGING",
-           "LOGGING",
-           "EXAMPLES", 
-           "PROJECT_ID",
-           "PG_REGION",
-        #    "PG_SCHEMA",
-           "PG_INSTANCE",
-           "PG_DATABASE",
-           "PG_USER",
-           "PG_PASSWORD", 
-           "BQ_REGION",
-        #    "BQ_DATASET_NAME",
-           "BQ_OPENDATAQNA_DATASET_NAME",
-           "BQ_LOG_TABLE_NAME",
-        #    "BQ_TABLE_LIST",
-           "FIRESTORE_REGION",
-           "PROMPTS"
-           "root_dir",
-           "save_config"]
+__all__ = [
+    "MODE",
+    "EMBEDDING_MODEL",
+    "DESCRIPTION_MODEL",
+    "VECTOR_STORE",
+    "LOGGING",
+    "EXAMPLES",
+    "USE_SESSION_HISTORY",
+    "USE_COLUMN_SAMPLES",
+    "PROJECT_ID",
+    "PG_REGION",
+    "PG_INSTANCE",
+    "PG_DATABASE",
+    "PG_USER",
+    "PG_PASSWORD",
+    "PG_CONN_STRING",
+    "BQ_REGION",
+    "BQ_OPENDATAQNA_DATASET_NAME",
+    "BQ_LOG_TABLE_NAME",
+    "FIRESTORE_REGION",
+    "PROMPTS",
+    "root_dir",
+    "format_prompt",
+]

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -1,25 +1,20 @@
+"""Utility helpers and configuration loading."""
+
+from __future__ import annotations
+
 import configparser
 import os
-import sys
 import yaml
+
 
 config = configparser.ConfigParser()
 
 
-def is_root_dir():
-    """
-    Checks if the current working directory is the root directory of a project
-    by looking for either the "/notebooks" or "/agents" folders.
-
-    Returns:
-        bool: True if either directory exists in the current directory, False otherwise.
-    """
-
+def is_root_dir() -> bool:
+    """Return True if the current working directory is the project root."""
     current_dir = os.getcwd()
-    print("current dir: ", current_dir)
     notebooks_path = os.path.join(current_dir, "notebooks")
     agents_path = os.path.join(current_dir, "agents")
-
     return os.path.exists(notebooks_path) or os.path.exists(agents_path)
 
 
@@ -28,68 +23,64 @@ def load_yaml(file_path: str) -> dict:
         return yaml.safe_load(f)
 
 
+# Determine root_dir and load config.ini
 if is_root_dir():
-    current_dir = os.getcwd()
-    config.read(current_dir + '/config.ini')
-    root_dir = current_dir
+    root_dir = os.getcwd()
 else:
-    root_dir = os.path.abspath(os.path.join(os.getcwd(), '..'))
-    config.read(root_dir + '/config.ini')
+    root_dir = os.path.abspath(os.path.join(os.getcwd(), ".."))
 
-if 'root_dir' not in locals():  # If not found in any parent dir
+config.read(os.path.join(root_dir, "config.ini"))
+if not config.sections():
     raise FileNotFoundError("config.ini not found in current or parent directories.")
-
-print(f'root_dir set to: {root_dir}')
 
 
 def format_prompt(context_prompt, **kwargs):
-    """
-    Formats a context prompt by replacing placeholders with values from keyword arguments.
-    Args:
-        context_prompt (str): The prompt string containing placeholders (e.g., {var1}).
-        **kwargs: Keyword arguments representing placeholder names and their values.
-    Returns:
-        str: The formatted prompt with placeholders replaced.
-    """
+    """Formats a context prompt by replacing placeholders with values."""
     return context_prompt.format(**kwargs)
 
 
-# [CONFIG]
-MODE = config['CONFIG'].get('MODE', 'gcp').lower()
+# [CONFIG] (codex/add-top-level-mode-flag-and-local-config 기준)
+MODE = config["CONFIG"].get("MODE", "gcp").lower()
 
-LOGGING = config.getboolean('CONFIG', 'LOGGING')
-EXAMPLES = config.getboolean('CONFIG', 'KGQ_EXAMPLES')
-USE_SESSION_HISTORY = config.getboolean('CONFIG', 'USE_SESSION_HISTORY')
-USE_COLUMN_SAMPLES = config.getboolean('CONFIG', 'USE_COLUMN_SAMPLES')
-FIRESTORE_REGION = config['CONFIG'].get('FIRESTORE_REGION', '')
+LOGGING = config.getboolean("CONFIG", "LOGGING")
+EXAMPLES = config.getboolean("CONFIG", "KGQ_EXAMPLES")
+USE_SESSION_HISTORY = config.getboolean("CONFIG", "USE_SESSION_HISTORY")
+USE_COLUMN_SAMPLES = config.getboolean("CONFIG", "USE_COLUMN_SAMPLES")
+FIRESTORE_REGION = config["CONFIG"].get("FIRESTORE_REGION", "")
 
-VECTOR_STORE = config['CONFIG'].get('VECTOR_STORE')
+VECTOR_STORE = config["CONFIG"].get("VECTOR_STORE")
 EMBEDDING_MODEL = None
 DESCRIPTION_MODEL = None
 
+# Defaults (filled per MODE)
 PROJECT_ID = PG_REGION = PG_INSTANCE = PG_DATABASE = PG_USER = PG_PASSWORD = None
 BQ_REGION = BQ_OPENDATAQNA_DATASET_NAME = BQ_LOG_TABLE_NAME = None
 PG_CONN_STRING = None
 
-if MODE == 'gcp':
-    EMBEDDING_MODEL = config['CONFIG']['EMBEDDING_MODEL']
-    DESCRIPTION_MODEL = config['CONFIG']['DESCRIPTION_MODEL']
-    PROJECT_ID = config['GCP']['PROJECT_ID']
-    PG_REGION = config['PGCLOUDSQL']['PG_REGION']
-    PG_INSTANCE = config['PGCLOUDSQL']['PG_INSTANCE']
-    PG_DATABASE = config['PGCLOUDSQL']['PG_DATABASE']
-    PG_USER = config['PGCLOUDSQL']['PG_USER']
-    PG_PASSWORD = config['PGCLOUDSQL']['PG_PASSWORD']
-    BQ_REGION = config['BIGQUERY']['BQ_DATASET_REGION']
-    BQ_OPENDATAQNA_DATASET_NAME = config['BIGQUERY']['BQ_OPENDATAQNA_DATASET_NAME']
-    BQ_LOG_TABLE_NAME = config['BIGQUERY']['BQ_LOG_TABLE_NAME']
-elif MODE == 'local':
-    PG_CONN_STRING = config['LOCAL']['PG_CONN_STRING']
-    EMBEDDING_MODEL = config['LOCAL']['EMBEDDING_MODEL_PATH']
-    DESCRIPTION_MODEL = config['LOCAL']['LLM_ENDPOINT']
+if MODE == "gcp":
+    EMBEDDING_MODEL = config["CONFIG"]["EMBEDDING_MODEL"]
+    DESCRIPTION_MODEL = config["CONFIG"]["DESCRIPTION_MODEL"]
+
+    PROJECT_ID = config["GCP"]["PROJECT_ID"]
+
+    PG_REGION = config["PGCLOUDSQL"]["PG_REGION"]
+    PG_INSTANCE = config["PGCLOUDSQL"]["PG_INSTANCE"]
+    PG_DATABASE = config["PGCLOUDSQL"]["PG_DATABASE"]
+    PG_USER = config["PGCLOUDSQL"]["PG_USER"]
+    PG_PASSWORD = config["PGCLOUDSQL"]["PG_PASSWORD"]
+
+    BQ_REGION = config["BIGQUERY"]["BQ_DATASET_REGION"]
+    BQ_OPENDATAQNA_DATASET_NAME = config["BIGQUERY"]["BQ_OPENDATAQNA_DATASET_NAME"]
+    BQ_LOG_TABLE_NAME = config["BIGQUERY"]["BQ_LOG_TABLE_NAME"]
+
+elif MODE == "local":
+    # Local/dev mode: single Postgres connection string and local model endpoints/paths
+    PG_CONN_STRING = config["LOCAL"]["PG_CONN_STRING"]
+    EMBEDDING_MODEL = config["LOCAL"]["EMBEDDING_MODEL_PATH"]
+    DESCRIPTION_MODEL = config["LOCAL"]["LLM_ENDPOINT"]
 
 # [PROMPTS]
-PROMPTS = load_yaml(root_dir + '/prompts.yaml')
+PROMPTS = load_yaml(os.path.join(root_dir, "prompts.yaml"))
 
 __all__ = [
     "MODE",


### PR DESCRIPTION
## Summary
- add top-level `mode` flag and local resource fields to `config.ini`
- allow utilities to switch between GCP and local resources based on `mode`
- provide `config.local.ini` example for a full local setup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae73b2e99c832db327f3ade57930c9