### PR TITLE
Add schema setup for papers embeddings

### DIFF
--- a/embeddings/papers_schema.py
+++ b/embeddings/papers_schema.py
@@ -1,0 +1,55 @@
+"""Create the papers_embeddings table and its HNSW index."""
+
+from __future__ import annotations
+
+import psycopg
+from pgvector.psycopg import register_vector
+from utilities import LOCAL_PG_CONN, PG_CONN_STRING
+
+
+# Normalize various Postgres URI schemes to libpq format
+
+def _normalize_pg_url(url: str) -> str:
+    return (
+        (url or "")
+        .strip()
+        .replace("postgresql+psycopg2://", "postgresql://")
+        .replace("postgres+psycopg2://", "postgresql://")
+        .replace("postgres://", "postgresql://")
+    )
+
+
+_CONNSTR = _normalize_pg_url(LOCAL_PG_CONN or PG_CONN_STRING or "")
+if not _CONNSTR:
+    raise RuntimeError("LOCAL_PG_CONN/PG_CONN_STRING must be set in config.ini")
+
+DDL_TABLE = """
+CREATE TABLE IF NOT EXISTS papers_embeddings (
+  id BIGSERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  abstract TEXT,
+  content TEXT NOT NULL,
+  metadata JSONB,
+  embedding vector(1024)
+);
+"""
+
+IDX = """
+CREATE INDEX IF NOT EXISTS idx_papers_embedding
+  ON papers_embeddings USING hnsw (embedding vector_cosine_ops)
+  WITH (m=16, ef_construction=64);
+"""
+
+
+def main() -> None:
+    with psycopg.connect(_CONNSTR) as conn:
+        register_vector(conn)
+        with conn.cursor() as cur:
+            cur.execute("CREATE EXTENSION IF NOT EXISTS vector;")
+            cur.execute(DDL_TABLE)
+            cur.execute(IDX)
+        conn.commit()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `papers_schema.py` to create `papers_embeddings` table with 1024-dim vector and HNSW index

## Testing
- `pytest` *(fails: connection to server at "localhost" (::1), port 5433 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a86c82f0832db79a3fe991c62e45