### PR TITLE
Add paper embedding and search APIs

### DIFF
--- a/backend-apis/README.md
+++ b/backend-apis/README.md
@@ -339,5 +339,50 @@ gcloud resource-manager org-policies delete iam.allowedPolicyMemberDomains --pro
     }
     ```
 
+8. Embed Papers : Store paper documents and their embeddings
+
+    URI: /papers/embed
+    Method: POST
+
+    Request Payload:
+    ```
+    [
+      {
+        "title": "Example title",
+        "abstract": "Optional abstract",
+        "content": "Full document text",
+        "metadata": {"source": "demo"}
+      }
+    ]
+    ```
+
+    Request response:
+    ```
+    {
+    "inserted": 1
+    }
+    ```
+
+9. Search Papers : Find similar papers using vector search
+
+    URI: /papers/search
+    Method: POST
+
+    Request Payload:
+    ```
+    {
+    "query": "climate change",
+    "k": 5,
+    "summarize": true
+    }
+    ```
+
+    Request response:
+    ```
+    {
+    "results": [{"id": 1, "title": "Example title", "abstract": "Optional abstract", "metadata": {"source": "demo"}}],
+    "summary": "Optional natural language summary"
+    }
+    ```
 
 ### For setting up the demo UI with these endpoints please refer to README.md under [`/frontend`](/frontend/)


### PR DESCRIPTION
## Summary
- expose `/papers/embed` API to store document embeddings in Postgres
- add `/papers/search` endpoint that performs pgvector similarity search and optional summarization
- document paper embedding and search usage

## Testing
- `pytest` *(fails: connection to server at "localhost" (::1), port 5433 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b3d99bf8832d8633dba2593e7fbc