### PR TITLE
Add OMOP concept chat endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,29 @@ For detailed steps and known issues refer to  README.md under [`/terraform`](/te
 ---------------------------------------------------
 Deploy backend apis for the solution, refer to the README.md under [`/backend-apis`](/backend-apis/). This APIs are designed with work with the frontend and provide access to run the solution.
 
+### OMOP Concept Chat API
+
+The backend now exposes a lightweight endpoint to ask vocabulary questions against the OMOP CDM catalog.
+
+* **Endpoint:** `POST /omop/concept_chat`
+* **Request body:**
+
+  ```json
+  {
+    "question": "What is the standard concept for SNOMED code 22298006?"
+  }
+  ```
+
+* **Response:**
+
+  ```json
+  {
+    "answer": "...model generated summary..."
+  }
+  ```
+
+Send the `question` field with the concept code or term you want to explore to receive curated OMOP concept details.
+
 Once the backend APIs deployed successfully deploy the frontend for the solution, refer to the README.md under [`/frontend`](/frontend/).
 
 

--- a/backend-apis/README.md
+++ b/backend-apis/README.md
@@ -385,4 +385,23 @@ gcloud resource-manager org-policies delete iam.allowedPolicyMemberDomains --pro
     }
     ```
 
+10. OMOP Concept Chat : Retrieve OMOP CDM vocabulary details for a concept code or term
+
+    URI: /omop/concept_chat
+    Method: POST
+
+    Request Payload:
+    ```
+    {
+      "question": "What concept represents ICD10 code E11?"
+    }
+    ```
+
+    Request response:
+    ```
+    {
+      "answer": "...model generated OMOP concept summary..."
+    }
+    ```
+
 ### For setting up the demo UI with these endpoints please refer to README.md under [`/frontend`](/frontend/)

--- a/backend-apis/main.py
+++ b/backend-apis/main.py
@@ -41,6 +41,7 @@ from pgvector.psycopg import register_vector
 firebase_admin.initialize_app()
 
 from services.chat import generate_sql_results as chat_generate_sql_results
+from services.omop_concept_chat import run as concept_chat_run
 
 from opendataqna import (
     get_all_databases,
@@ -257,6 +258,16 @@ async def chat():
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
+
+
+@app.route("/omop/concept_chat", methods=["POST"])
+async def omop_concept_chat():
+    payload = request.get_json(silent=True) or {}
+    question = payload.get("question", "")
+    if not question:
+        return jsonify({"Error": "question required"}), 400
+    answer = await concept_chat_run(question)
+    return jsonify({"answer": answer})
 
 
 @app.route("/get_known_sql", methods=["POST"])

--- a/config.ini
+++ b/config.ini
@@ -94,6 +94,10 @@ bq_opendataqna_dataset_name = opendataqna
 bq_log_table_name = audit_log_table
 
 
+[OMOP]
+concept_chat_model = gemini-1.5-pro
+
+
 [LOCAL]
 # 로컬 PostgreSQL 연결 정보
 pg_conn_string = postgresql://postgres:secretpw@localhost:5433/opendataqna

--- a/prompts.yaml
+++ b/prompts.yaml
@@ -78,6 +78,16 @@ buildsql_bigquery: |
   {columns_schema}
   </Columns Schema>
 
+omop_concept_chat: |
+  You are an assistant specializing in OMOP CDM vocabulary.
+  Given a user question about concept codes or terms, return:
+  - concept_id, concept_name, vocabulary_id, domain_id, concept_class_id
+  - brief description and major relationships (e.g., parent/child or mapping)
+  - If the code or term is not found, state that it is not present in OMOP CDM.
+  Use concise bullet points and cite concept IDs where available.
+
+  User question: {question}
+
 # DO NOT CHANGE PROMPT VARIABLE NAME
 # Prompt for building sql query for PostgreSQL
 buildsql_cloudsql-pg: |

--- a/services/omop_concept_chat.py
+++ b/services/omop_concept_chat.py
@@ -1,0 +1,34 @@
+"""Service for handling OMOP concept chat requests."""
+
+from __future__ import annotations
+
+import asyncio
+from functools import lru_cache
+
+from agents import ResponseAgent
+from utilities import PROMPTS, config, format_prompt
+
+
+@lru_cache(maxsize=1)
+def _get_agent() -> ResponseAgent:
+    """Return a cached :class:`ResponseAgent` for OMOP concept chat."""
+
+    model = config.get("OMOP", "CONCEPT_CHAT_MODEL", fallback="gemini-1.5-pro")
+    return ResponseAgent(model)
+
+
+async def run(question: str) -> str:
+    """Generate an OMOP concept chat response for ``question``.
+
+    Args:
+        question: The user question about OMOP vocabulary concepts.
+
+    Returns:
+        The language model response formatted according to the prompt template.
+    """
+
+    prompt_template = PROMPTS["omop_concept_chat"]
+    formatted_prompt = format_prompt(prompt_template, question=question)
+    agent = _get_agent()
+    return await asyncio.to_thread(agent.generate_llm_response, formatted_prompt)
+


### PR DESCRIPTION
## Summary
- add an OMOP concept chat prompt and service backed by the ResponseAgent
- expose a new /omop/concept_chat API route that validates input and returns model output
- document the endpoint and surface its model configuration option in config.ini

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'psycopg')*


------
https://chatgpt.com/codex/tasks/task_e_68c8a5b88dc8832d97d64d6f263433a4