### PR TITLE
Add OMOP concept embedding ingestion and retrieval service

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,13 +1,46 @@
-from .BuildSQLAgent import BuildSQLAgent
-from .ValidateSQLAgent import ValidateSQLAgent
-from .DebugSQLAgent import DebugSQLAgent
-from .EmbedderAgent import EmbedderAgent
-from .ResponseAgent import ResponseAgent
-from .VisualizeAgent import VisualizeAgent
-from .DescriptionAgent import DescriptionAgent
+__all__ = [
+    "BuildSQLAgent",
+    "ValidateSQLAgent",
+    "DebugSQLAgent",
+    "EmbedderAgent",
+    "ResponseAgent",
+    "ResponseAgent_Local",
+    "VisualizeAgent",
+    "DescriptionAgent",
+]
 
 
+def __getattr__(name):
+    if name == "BuildSQLAgent":
+        from .BuildSQLAgent import BuildSQLAgent
 
-__all__ = ["BuildSQLAgent", "ValidateSQLAgent", "DebugSQLAgent", "EmbedderAgent", "ResponseAgent","VisualizeAgent", "DescriptionAgent"]
+        return BuildSQLAgent
+    if name == "ValidateSQLAgent":
+        from .ValidateSQLAgent import ValidateSQLAgent
 
+        return ValidateSQLAgent
+    if name == "DebugSQLAgent":
+        from .DebugSQLAgent import DebugSQLAgent
 
+        return DebugSQLAgent
+    if name == "EmbedderAgent":
+        from .EmbedderAgent import EmbedderAgent
+
+        return EmbedderAgent
+    if name == "ResponseAgent":
+        from .ResponseAgent import ResponseAgent
+
+        return ResponseAgent
+    if name == "ResponseAgent_Local":
+        from .ResponseAgent_Local import ResponseAgent as ResponseAgentLocal
+
+        return ResponseAgentLocal
+    if name == "VisualizeAgent":
+        from .VisualizeAgent import VisualizeAgent
+
+        return VisualizeAgent
+    if name == "DescriptionAgent":
+        from .DescriptionAgent import DescriptionAgent
+
+        return DescriptionAgent
+    raise AttributeError(name)

--- a/backend-apis/main.py
+++ b/backend-apis/main.py
@@ -280,8 +280,13 @@ async def omop_concept_chat():
     question = payload.get("question", "")
     if not question:
         return jsonify({"Error": "question required"}), 400
-    answer = await concept_chat_run(question)
-    return jsonify({"answer": answer})
+    top_k = payload.get("top_k")
+    try:
+        top_k_int = int(top_k) if top_k is not None else 5
+    except (TypeError, ValueError):
+        top_k_int = 5
+    answer_payload = await concept_chat_run(question, top_k=top_k_int)
+    return jsonify(answer_payload)
 
 
 @app.route("/get_known_sql", methods=["POST"])

--- a/embeddings/__init__.py
+++ b/embeddings/__init__.py
@@ -1,8 +1,12 @@
-from .store_embeddings import store_embeddings as store_schema_embeddings, store_embeddings
 from .retrieve_embeddings import retrieve_embeddings
 
-__all__ = [
-    "retrieve_embeddings",
-    "store_embeddings",
-    "store_schema_embeddings",  # 과거 코드 호환용
-]
+try:  # Optional dependency: store_embeddings requires psycopg
+    from .store_embeddings import store_embeddings as store_schema_embeddings, store_embeddings
+except ModuleNotFoundError:  # pragma: no cover - import guard
+    def store_embeddings(*args, **kwargs):  # type: ignore[override]
+        raise RuntimeError("psycopg is required to store embeddings")
+
+    def store_schema_embeddings(*args, **kwargs):  # type: ignore[override]
+        raise RuntimeError("psycopg is required to store embeddings")
+
+__all__ = ["retrieve_embeddings", "store_embeddings", "store_schema_embeddings"]

--- a/embeddings/omop_concept_embeddings.py
+++ b/embeddings/omop_concept_embeddings.py
@@ -1,0 +1,310 @@
+"""Utilities for ingesting OMOP concept embeddings into pgvector."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable, Iterator, List, Dict, Any, Sequence
+
+import psycopg
+from pgvector.psycopg import register_vector
+
+try:  # Optional dependency; EmbedderAgent may yield numpy arrays
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover - numpy is optional
+    np = None  # type: ignore
+
+from agents import EmbedderAgent
+from dbconnectors import pgconnector
+from utilities import (
+    EMBEDDING_MODEL,
+    EMBEDDING_MODEL_PATH,
+    LOCAL_PG_CONN,
+    PG_CONN_STRING,
+    config,
+)
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL connection helpers (mirrors embeddings.store_embeddings)
+# ---------------------------------------------------------------------------
+
+def _normalize_pg_url(url: str) -> str:
+    """Normalise SQLAlchemy-style URLs to libpq format."""
+
+    return (
+        (url or "").strip()
+        .replace("postgresql+psycopg2://", "postgresql://")
+        .replace("postgres+psycopg2://", "postgresql://")
+        .replace("postgres://", "postgresql://")
+    )
+
+
+_PG_CONNSTR = _normalize_pg_url(LOCAL_PG_CONN or PG_CONN_STRING or "")
+if not _PG_CONNSTR:
+    raise RuntimeError("LOCAL_PG_CONN or PG_CONN_STRING must be defined in config.ini")
+
+
+def _pg_connect() -> psycopg.Connection:
+    """Return a psycopg connection using the configured connection string."""
+
+    return psycopg.connect(_PG_CONNSTR)
+
+
+# ---------------------------------------------------------------------------
+# Data modelling helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_list(vector: Sequence[float] | Any) -> List[float]:
+    """Coerce embedding vectors into JSON-serialisable lists."""
+
+    if isinstance(vector, list):
+        return [float(x) for x in vector]
+    if isinstance(vector, tuple):
+        return [float(x) for x in vector]
+    if np is not None and isinstance(vector, np.ndarray):  # pragma: no branch
+        return vector.astype(float).tolist()
+    raise TypeError(f"Unsupported embedding vector type: {type(vector)!r}")
+
+
+@dataclass
+class ConceptPayload:
+    concept_id: int
+    concept_name: str
+    domain_id: str | None
+    vocabulary_id: str | None
+    concept_class_id: str | None
+    description: str
+    embedding: List[float]
+
+    def to_row(self) -> tuple[Any, ...]:
+        return (
+            self.concept_id,
+            self.concept_name,
+            self.domain_id,
+            self.vocabulary_id,
+            self.concept_class_id,
+            self.description,
+            self.embedding,
+        )
+
+
+def _resolve_embedding_model() -> str:
+    """Pick an embedding model using config fallbacks."""
+
+    configured = config.get("OMOP", "CONCEPT_EMBEDDING_MODEL", fallback="").strip()
+    if configured:
+        return configured
+    if EMBEDDING_MODEL_PATH:
+        return EMBEDDING_MODEL_PATH
+    if EMBEDDING_MODEL:
+        return EMBEDDING_MODEL
+    return "BAAI/bge-m3"
+
+
+@lru_cache(maxsize=1)
+def _get_embedder() -> EmbedderAgent:
+    """Return a cached local embedder instance."""
+
+    return EmbedderAgent("local", _resolve_embedding_model())
+
+
+# ---------------------------------------------------------------------------
+# Query helpers
+# ---------------------------------------------------------------------------
+
+_CONCEPT_QUERY = """
+WITH base AS (
+    SELECT
+        c.concept_id,
+        c.concept_name,
+        c.domain_id,
+        c.vocabulary_id,
+        c.concept_class_id,
+        COALESCE(string_agg(DISTINCT cs.concept_synonym_name, '; '), '') AS synonyms,
+        COALESCE(
+            string_agg(
+                DISTINCT CONCAT(r.relationship_name, ': ', c2.concept_name),
+                '; '
+            ),
+            ''
+        ) AS relationships
+    FROM concept c
+    LEFT JOIN concept_synonym cs
+        ON cs.concept_id = c.concept_id
+    LEFT JOIN concept_relationship cr
+        ON cr.concept_id_1 = c.concept_id
+        AND cr.invalid_reason IS NULL
+    LEFT JOIN relationship r
+        ON r.relationship_id = cr.relationship_id
+    LEFT JOIN concept c2
+        ON c2.concept_id = cr.concept_id_2
+    WHERE c.invalid_reason IS NULL
+    GROUP BY c.concept_id, c.concept_name, c.domain_id, c.vocabulary_id, c.concept_class_id
+)
+SELECT * FROM base ORDER BY concept_id
+"""
+
+
+def _fetch_concepts(limit: int | None = None):
+    """Retrieve the raw concept metadata as a pandas DataFrame."""
+
+    query = _CONCEPT_QUERY
+    if limit:
+        query = f"{query}\nLIMIT {int(limit)}"
+    return pgconnector.retrieve_df(query)
+
+
+def _build_description(record: Dict[str, Any]) -> str:
+    """Create a compact natural-language payload for a concept."""
+
+    synonyms = (record.get("synonyms") or "").strip()
+    relationships = (record.get("relationships") or "").strip()
+
+    parts = [
+        f"concept_id {record['concept_id']} — {record['concept_name']}",
+        f"Domain: {record.get('domain_id') or 'N/A'}",
+        f"Vocabulary: {record.get('vocabulary_id') or 'N/A'}",
+        f"Class: {record.get('concept_class_id') or 'N/A'}",
+    ]
+    if synonyms:
+        parts.append(f"Synonyms: {synonyms}")
+    if relationships:
+        parts.append(f"Relationships: {relationships}")
+    return "\n".join(parts)
+
+
+def _chunk_iter(iterable: Iterable[Dict[str, Any]], size: int) -> Iterator[List[Dict[str, Any]]]:
+    """Yield chunks from *iterable* with the given *size*."""
+
+    bucket: List[Dict[str, Any]] = []
+    for item in iterable:
+        bucket.append(item)
+        if len(bucket) >= size:
+            yield bucket
+            bucket = []
+    if bucket:
+        yield bucket
+
+
+# ---------------------------------------------------------------------------
+# Schema preparation and persistence
+# ---------------------------------------------------------------------------
+
+DDL_TABLE_TEMPLATE = """
+CREATE TABLE IF NOT EXISTS omop_concept_embeddings (
+  concept_id      BIGINT PRIMARY KEY,
+  concept_name    TEXT NOT NULL,
+  domain_id       TEXT,
+  vocabulary_id   TEXT,
+  concept_class_id TEXT,
+  description     TEXT NOT NULL,
+  embedding       vector({dim}) NOT NULL
+);
+"""
+
+IDX_TABLE = """
+CREATE INDEX IF NOT EXISTS idx_omop_concept_embeddings_cos
+  ON omop_concept_embeddings USING hnsw (embedding vector_cosine_ops)
+  WITH (m=16, ef_construction=64);
+"""
+
+SQL_UPSERT = """
+INSERT INTO omop_concept_embeddings (
+    concept_id,
+    concept_name,
+    domain_id,
+    vocabulary_id,
+    concept_class_id,
+    description,
+    embedding
+) VALUES (%s, %s, %s, %s, %s, %s, %s)
+ON CONFLICT (concept_id) DO UPDATE SET
+    concept_name = EXCLUDED.concept_name,
+    domain_id = EXCLUDED.domain_id,
+    vocabulary_id = EXCLUDED.vocabulary_id,
+    concept_class_id = EXCLUDED.concept_class_id,
+    description = EXCLUDED.description,
+    embedding = EXCLUDED.embedding;
+"""
+
+
+def _prepare_schema(dim: int) -> None:
+    if dim <= 0:
+        raise ValueError("Embedding dimension must be positive")
+
+    ddl = DDL_TABLE_TEMPLATE.format(dim=dim)
+    with _pg_connect() as conn:
+        register_vector(conn)
+        with conn.cursor() as cur:
+            cur.execute("CREATE EXTENSION IF NOT EXISTS vector;")
+            cur.execute(ddl)
+            cur.execute(IDX_TABLE)
+        conn.commit()
+
+
+def _persist_payloads(payloads: Iterable[ConceptPayload]) -> int:
+    inserted = 0
+    with _pg_connect() as conn:
+        register_vector(conn)
+        with conn.cursor() as cur:
+            cur.execute("CREATE EXTENSION IF NOT EXISTS vector;")
+            for payload in payloads:
+                cur.execute(SQL_UPSERT, payload.to_row())
+                inserted += 1
+        conn.commit()
+    return inserted
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+
+def ingest_omop_concepts(limit: int | None = None, batch_size: int = 100) -> int:
+    """Fetch OMOP concept metadata, embed it, and persist to pgvector."""
+
+    df = _fetch_concepts(limit)
+    if df is None or df.empty:
+        return 0
+
+    records = df.fillna("").to_dict(orient="records")
+    embedder = _get_embedder()
+
+    all_payloads: List[ConceptPayload] = []
+    embedding_dim: int | None = None
+
+    for chunk in _chunk_iter(records, max(1, batch_size)):
+        descriptions = [_build_description(rec) for rec in chunk]
+        embeddings = embedder.create(descriptions)
+        if not isinstance(embeddings, list):
+            raise TypeError("EmbedderAgent.create must return a list for batch inputs")
+        if len(embeddings) != len(chunk):
+            raise ValueError("Embedding count mismatch for OMOP concept ingestion")
+
+        for rec, emb in zip(chunk, embeddings):
+            emb_list = _to_list(emb)
+            embedding_dim = embedding_dim or len(emb_list)
+            all_payloads.append(
+                ConceptPayload(
+                    concept_id=int(rec["concept_id"]),
+                    concept_name=str(rec["concept_name"]),
+                    domain_id=rec.get("domain_id") or None,
+                    vocabulary_id=rec.get("vocabulary_id") or None,
+                    concept_class_id=rec.get("concept_class_id") or None,
+                    description=_build_description(rec),
+                    embedding=emb_list,
+                )
+            )
+
+    if embedding_dim is None:
+        return 0
+
+    _prepare_schema(embedding_dim)
+    return _persist_payloads(all_payloads)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    count = ingest_omop_concepts()
+    print(f"Ingested {count} OMOP concept embeddings.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ sentence-transformers = "^2.6.1"
 pyzmq ="<26.0.0"
 ipykernel = "^6.29.3"
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/services/omop_concept_chat.py
+++ b/services/omop_concept_chat.py
@@ -4,31 +4,190 @@ from __future__ import annotations
 
 import asyncio
 from functools import lru_cache
+from typing import Any, Dict, List, Sequence
 
-from agents import ResponseAgent_Local
-from utilities import PROMPTS, config, format_prompt
+try:  # psycopg is optional during unit tests
+    import psycopg
+    from psycopg import errors
+    from psycopg.rows import dict_row
+    from pgvector.psycopg import register_vector
+    _PSYCOPG_IMPORT_ERROR: Exception | None = None
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    psycopg = None  # type: ignore
+    errors = None  # type: ignore
+    dict_row = None  # type: ignore
+    register_vector = None  # type: ignore
+    _PSYCOPG_IMPORT_ERROR = exc
+
+from agents.EmbedderAgent import EmbedderAgent
+from agents.ResponseAgent_Local import ResponseAgent as ResponseAgentLocal
+from utilities import (
+    EMBEDDING_MODEL,
+    EMBEDDING_MODEL_PATH,
+    LOCAL_PG_CONN,
+    PG_CONN_STRING,
+    PROMPTS,
+    config,
+    format_prompt,
+)
+
+
+def _normalize_pg_url(url: str) -> str:
+    return (
+        (url or "").strip()
+        .replace("postgresql+psycopg2://", "postgresql://")
+        .replace("postgres+psycopg2://", "postgresql://")
+        .replace("postgres://", "postgresql://")
+    )
+
+
+_PG_CONNSTR = _normalize_pg_url(LOCAL_PG_CONN or PG_CONN_STRING or "")
+if not _PG_CONNSTR:
+    raise RuntimeError("LOCAL_PG_CONN or PG_CONN_STRING must be defined in config.ini")
+
+
+def _pg_connect() -> "psycopg.Connection":
+    if psycopg is None:  # pragma: no cover - exercised in tests via monkeypatch
+        raise RuntimeError("psycopg is required for OMOP concept chat") from _PSYCOPG_IMPORT_ERROR
+    return psycopg.connect(_PG_CONNSTR)
+
+
+def _resolve_embedding_model() -> str:
+    configured = config.get("OMOP", "CONCEPT_EMBEDDING_MODEL", fallback="").strip()
+    if configured:
+        return configured
+    if EMBEDDING_MODEL_PATH:
+        return EMBEDDING_MODEL_PATH
+    if EMBEDDING_MODEL:
+        return EMBEDDING_MODEL
+    return "BAAI/bge-m3"
+
 
 @lru_cache(maxsize=1)
-# def _get_agent() -> ResponseAgent_Local:
-#     """Return a cached :class:`ResponseAgent` for OMOP concept chat."""
-#
-#     model = config.get("OMOP", "CONCEPT_CHAT_MODEL", fallback="gemini-1.5-pro")
-#     return ResponseAgent_Local(model)
+def _get_embedder() -> EmbedderAgent:
+    return EmbedderAgent("local", _resolve_embedding_model())
 
 
-async def run(question: str) -> str:
-    """Generate an OMOP concept chat response for ``question``.
+@lru_cache(maxsize=1)
+def _get_agent() -> ResponseAgentLocal:
+    model = config.get("OMOP", "CONCEPT_CHAT_MODEL", fallback="").strip()
+    if model:
+        return ResponseAgentLocal(model=model)
+    return ResponseAgentLocal()
 
-    Args:
-        question: The user question about OMOP vocabulary concepts.
 
-    Returns:
-        The language model response formatted according to the prompt template.
-    """
+def _format_concept_context(concepts: Sequence[Dict[str, Any]]) -> str:
+    lines: List[str] = []
+    for concept in concepts:
+        header = (
+            f"- concept_id {concept['concept_id']} ({concept['concept_name']})"
+            f" | vocabulary: {concept.get('vocabulary_id') or 'N/A'}"
+            f" | domain: {concept.get('domain_id') or 'N/A'}"
+            f" | class: {concept.get('concept_class_id') or 'N/A'}"
+        )
+        description = (concept.get("description") or "").strip()
+        if description:
+            lines.append(f"{header}\n  {description}")
+        else:
+            lines.append(header)
+    if not lines:
+        return "- 검색된 개념이 없습니다. 기본 지식을 활용하세요."
+    return "\n".join(lines)
+
+
+def _to_float_list(vector: Sequence[float] | Sequence[Any]) -> List[float]:
+    return [float(x) for x in vector]
+
+
+def _query_similar_concepts(query_embedding: Sequence[float], limit: int = 5) -> List[Dict[str, Any]]:
+    if psycopg is None or register_vector is None or dict_row is None:
+        return []
+
+    if not query_embedding:
+        return []
+
+    embedding = _to_float_list(query_embedding)
+    if not embedding:
+        return []
+
+    try:
+        with _pg_connect() as conn:
+            register_vector(conn)
+            with conn.cursor(row_factory=dict_row) as cur:
+                cur.execute("CREATE EXTENSION IF NOT EXISTS vector;")
+                cur.execute(
+                    """
+                    SELECT
+                        concept_id,
+                        concept_name,
+                        domain_id,
+                        vocabulary_id,
+                        concept_class_id,
+                        description,
+                        1 - (embedding <=> %s) AS similarity
+                    FROM omop_concept_embeddings
+                    ORDER BY embedding <=> %s
+                    LIMIT %s;
+                    """,
+                    (embedding, embedding, limit),
+                )
+                rows = cur.fetchall()
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        if psycopg is not None:
+            if errors is not None and isinstance(exc, errors.UndefinedTable):
+                return []
+            if isinstance(exc, psycopg.OperationalError):
+                return []
+        raise
+
+    concepts: List[Dict[str, Any]] = []
+    for row in rows:
+        similarity = row.get("similarity")
+        if similarity is not None:
+            similarity = float(similarity)
+        concepts.append(
+            {
+                "concept_id": row["concept_id"],
+                "concept_name": row["concept_name"],
+                "domain_id": row.get("domain_id"),
+                "vocabulary_id": row.get("vocabulary_id"),
+                "concept_class_id": row.get("concept_class_id"),
+                "description": row.get("description"),
+                "similarity": similarity,
+            }
+        )
+    return concepts
+
+
+def _extract_embedding(raw_embedding: Any) -> List[float]:
+    if isinstance(raw_embedding, list):
+        if raw_embedding and isinstance(raw_embedding[0], (float, int)):
+            return _to_float_list(raw_embedding)
+        if raw_embedding and isinstance(raw_embedding[0], list):
+            return _to_float_list(raw_embedding[0])
+    raise TypeError("EmbedderAgent.create returned an unexpected embedding format")
+
+
+async def run(question: str, *, top_k: int = 5) -> Dict[str, Any]:
+    """Generate an OMOP concept chat response enriched with retrieved concepts."""
+
+    embedder = _get_embedder()
+    raw_embedding = embedder.create(question)
+    query_embedding = _extract_embedding(raw_embedding)
+    concepts = _query_similar_concepts(query_embedding, limit=top_k)
 
     prompt_template = PROMPTS["omop_concept_chat"]
-    formatted_prompt = format_prompt(prompt_template, question=question)
-    agent = ResponseAgent_Local.ResponseAgent()  # ← 괄호 추가해서 인스턴스 생성
-    return await asyncio.to_thread(agent.generate_llm_response, formatted_prompt)
+    base_prompt = format_prompt(prompt_template, question=question)
+    context_block = _format_concept_context(concepts)
+    final_prompt = f"{base_prompt}\n\n[Retrieved OMOP Concepts]\n{context_block}"
+
+    agent = _get_agent()
+    answer = await asyncio.to_thread(agent.generate_llm_response, final_prompt)
+
+    return {
+        "answer": answer,
+        "concepts": concepts,
+        "prompt": final_prompt,
+    }
 
 

--- a/tests/test_omop_concept_chat.py
+++ b/tests/test_omop_concept_chat.py
@@ -1,0 +1,51 @@
+import asyncio
+import pytest
+
+from services import omop_concept_chat
+
+
+def test_run_includes_concepts_in_prompt_and_response(monkeypatch):
+    # Ensure cached factories do not leak between tests
+    omop_concept_chat._get_embedder.cache_clear()
+    omop_concept_chat._get_agent.cache_clear()
+
+    captured_prompt = {}
+
+    class FakeEmbedder:
+        def create(self, question):
+            assert question == "What is concept 123?"
+            return [0.1, 0.2, 0.3]
+
+    class FakeAgent:
+        def generate_llm_response(self, prompt):
+            captured_prompt["value"] = prompt
+            return "fake answer"
+
+    sample_concepts = [
+        {
+            "concept_id": 123,
+            "concept_name": "Hypertension",
+            "domain_id": "Condition",
+            "vocabulary_id": "SNOMED",
+            "concept_class_id": "Clinical Finding",
+            "description": "concept_id 123 — Hypertension\nDomain: Condition\nVocabulary: SNOMED\nClass: Clinical Finding\nSynonyms: High blood pressure",
+            "similarity": 0.95,
+        }
+    ]
+
+    monkeypatch.setattr(omop_concept_chat, "_get_embedder", lambda: FakeEmbedder())
+    monkeypatch.setattr(omop_concept_chat, "_get_agent", lambda: FakeAgent())
+    monkeypatch.setattr(
+        omop_concept_chat,
+        "_query_similar_concepts",
+        lambda embedding, limit=5: sample_concepts,
+    )
+
+    payload = asyncio.run(omop_concept_chat.run("What is concept 123?", top_k=3))
+
+    assert payload["answer"] == "fake answer"
+    assert payload["concepts"] == sample_concepts
+    assert payload["prompt"] == captured_prompt["value"]
+    assert "concept_id 123" in payload["prompt"]
+    assert "Hypertension" in payload["prompt"]
+    assert "[Retrieved OMOP Concepts]" in payload["prompt"]


### PR DESCRIPTION
## Summary
- add an ingestion utility that builds an `omop_concept_embeddings` pgvector table from OMOP concept metadata and embeddings
- enhance the OMOP concept chat service to embed questions, retrieve similar concepts, and surface them in responses while reusing pgvector helpers
- expose the retrieved concepts via the API, make agent imports lazy-safe, narrow pytest discovery, and add unit coverage for the new prompt behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ca60b87064832d9de3ba96a4bf855e