### PR TITLE
Persist chat history to audit database

### DIFF
--- a/dbconnectors/LocalPgConnector.py
+++ b/dbconnectors/LocalPgConnector.py
@@ -21,6 +21,7 @@ import scripts
 from .core import DBConnector
 
 from datetime import datetime
+from typing import Optional
 
 from utilities import root_dir
 # from google.cloud.sql.connector import Connector
@@ -775,8 +776,27 @@ class LocalPgConnector(DBConnector, ABC):
                     execution_time TIMESTAMPTZ,
                     full_log TEXT
                 );
-                """)
-            )
+                """
+            ))
+            conn.execute(text(
+                """
+                CREATE TABLE IF NOT EXISTS chat_history_log (
+                    id SERIAL PRIMARY KEY,
+                    chat_id TEXT NOT NULL,
+                    session_id TEXT,
+                    question_type INTEGER,
+                    question TEXT,
+                    answer TEXT,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                );
+                """
+            ))
+            conn.execute(text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_chat_history_log_chat_created
+                    ON chat_history_log (chat_id, created_at);
+                """
+            ))
             conn.commit()
 
     def make_audit_entry(
@@ -815,6 +835,74 @@ class LocalPgConnector(DBConnector, ABC):
             conn.execute(stmt, params)
             conn.commit()
         return "OK"
+
+    def make_chat_history_entry(
+        self,
+        chat_id: str,
+        session_id: Optional[str],
+        question_type: Optional[int],
+        question: str,
+        answer: str,
+        *,
+        created_at: datetime | None = None,
+    ) -> None:
+        if created_at is None:
+            created_at = datetime.utcnow()
+
+        with self.getconn() as conn:
+            stmt = text(
+                """
+                INSERT INTO chat_history_log
+                    (chat_id, session_id, question_type, question, answer, created_at)
+                VALUES
+                    (:chat_id, :session_id, :question_type, :question, :answer, :created_at)
+                """
+            )
+            params = {
+                "chat_id": chat_id,
+                "session_id": session_id,
+                "question_type": question_type,
+                "question": question,
+                "answer": answer,
+                "created_at": created_at,
+            }
+            conn.execute(stmt, params)
+            conn.commit()
+
+    def get_chat_history(self, chat_id: str, limit: int) -> list[dict[str, object]]:
+        with self.getconn() as conn:
+            stmt = text(
+                """
+                SELECT chat_id, session_id, question_type, question, answer, created_at
+                FROM chat_history_log
+                WHERE chat_id = :chat_id
+                ORDER BY created_at ASC
+                LIMIT :limit
+                """
+            )
+            result = conn.execute(stmt, {"chat_id": chat_id, "limit": limit})
+            rows = result.mappings().all()
+
+        history: list[dict[str, object]] = []
+        for row in rows:
+            created_at = row.get("created_at")
+            if isinstance(created_at, datetime):
+                created_at_str = created_at.isoformat()
+            else:
+                created_at_str = str(created_at)
+
+            history.append(
+                {
+                    "chatId": row.get("chat_id"),
+                    "sessionId": row.get("session_id"),
+                    "questionType": row.get("question_type"),
+                    "question": row.get("question"),
+                    "answer": row.get("answer"),
+                    "timestamp": created_at_str,
+                }
+            )
+
+        return history
 
 __all__ = ["LocalPgConnector"]
 


### PR DESCRIPTION
## Summary
- provision a `chat_history_log` table alongside the audit log in the PostgreSQL connectors and expose helpers to write and read chat turns
- update the unified `/api/chat` handler to load persisted turns for each chatId and record every exchange in the audit database while keeping session tracking intact

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d3b46b7834832d94de0a8c6e7ce537