### PR TITLE
Switch to psycopg 3

### DIFF
--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -15,7 +15,7 @@ connector_backend = local
 
 [LOCAL]
 # PostgreSQL connection string
-pg_conn = postgresql+psycopg2://user:pass@localhost:5432/opendataqna
+pg_conn = postgresql+psycopg://user:pass@localhost:5432/opendataqna
 # SQLite database used for the BigQuery and Firestore connectors
 sqlite_db = opendataqna.db
 ```

--- a/embeddings/omop_concept_embeddings.py
+++ b/embeddings/omop_concept_embeddings.py
@@ -34,7 +34,9 @@ def _normalize_pg_url(url: str) -> str:
     return (
         (url or "").strip()
         .replace("postgresql+psycopg2://", "postgresql://")
+        .replace("postgresql+psycopg://", "postgresql://")
         .replace("postgres+psycopg2://", "postgresql://")
+        .replace("postgres+psycopg://", "postgresql://")
         .replace("postgres://", "postgresql://")
     )
 

--- a/embeddings/papers_schema.py
+++ b/embeddings/papers_schema.py
@@ -14,7 +14,9 @@ def _normalize_pg_url(url: str) -> str:
         (url or "")
         .strip()
         .replace("postgresql+psycopg2://", "postgresql://")
+        .replace("postgresql+psycopg://", "postgresql://")
         .replace("postgres+psycopg2://", "postgresql://")
+        .replace("postgres+psycopg://", "postgresql://")
         .replace("postgres://", "postgresql://")
     )
 

--- a/embeddings/store_embeddings.py
+++ b/embeddings/store_embeddings.py
@@ -17,7 +17,9 @@ from utilities import PG_VECTOR_CONN, EMBEDDING_MODEL, VECTOR_STORE, PG_LOCAL, L
 def _normalize_pg_url(url: str) -> str:
     return (url or "").strip()\
         .replace("postgresql+psycopg2://", "postgresql://")\
+        .replace("postgresql+psycopg://", "postgresql://")\
         .replace("postgres+psycopg2://", "postgresql://")\
+        .replace("postgres+psycopg://", "postgresql://")\
         .replace("postgres://", "postgresql://")
 
 _PG_CONNSTR = _normalize_pg_url(PG_VECTOR_CONN or "")

--- a/embeddings/store_papers.py
+++ b/embeddings/store_papers.py
@@ -41,7 +41,9 @@ def _normalize_pg_url(url: str) -> str:
     return (
         (url or "").strip()
         .replace("postgresql+psycopg2://", "postgresql://")
+        .replace("postgresql+psycopg://", "postgresql://")
         .replace("postgres+psycopg2://", "postgresql://")
+        .replace("postgres+psycopg://", "postgresql://")
         .replace("postgres://", "postgresql://")
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ cloud-sql-python-connector = {extras = ["asyncpg"], version = "^1.7.0"}
 sqlalchemy = "^2.0.27"
 pgvector = "^0.2.5"
 pg8000 = "^1.30.5"
-psycopg2-binary = "^2.9.9"
+psycopg = {extras = ["binary"], version = "^3.1.18"}
 tabulate = "^0.9.0"
 langchain = "^0.1.9"
 fsspec = "^2024.2.0"

--- a/services/omop_concept_chat.py
+++ b/services/omop_concept_chat.py
@@ -35,7 +35,9 @@ def _normalize_pg_url(url: str) -> str:
     return (
         (url or "").strip()
         .replace("postgresql+psycopg2://", "postgresql://")
+        .replace("postgresql+psycopg://", "postgresql://")
         .replace("postgres+psycopg2://", "postgresql://")
+        .replace("postgres+psycopg://", "postgresql://")
         .replace("postgres://", "postgresql://")
     )
 


### PR DESCRIPTION
## Summary
- replace the psycopg2 dependency with psycopg 3 and binary extras
- normalize PostgreSQL connection string helpers to accept psycopg driver prefixes
- update local setup instructions to recommend the psycopg SQLAlchemy URL

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d61f5f7848832dbb0424cd7911e4f5