### PR TITLE
Align chat service defaults with local models

### DIFF
--- a/services/chat.py
+++ b/services/chat.py
@@ -1,6 +1,8 @@
 import asyncio
 import pandas as pd
 
+from utilities import CHAT_MODEL
+
 # Default arguments for run_pipeline. These mirror the previous hard-coded
 # values used in the Streamlit app and API server.
 _DEFAULT_PIPELINE_ARGS = dict(
@@ -9,9 +11,9 @@ _DEFAULT_PIPELINE_ARGS = dict(
     DEBUGGING_ROUNDS=2,
     LLM_VALIDATION=False,
     Embedder_model="local",
-    SQLBuilder_model="gemini-1.5-pro",
-    SQLChecker_model="gemini-1.5-pro",
-    SQLDebugger_model="gemini-1.5-pro",
+    SQLBuilder_model=CHAT_MODEL,
+    SQLChecker_model=CHAT_MODEL,
+    SQLDebugger_model=CHAT_MODEL,
     num_table_matches=5,
     num_column_matches=10,
     table_similarity_threshold=0.1,

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -8,6 +8,7 @@ import asyncio
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from services import chat
+from utilities import CHAT_MODEL
 
 
 def test_generate_sql_results_returns_dataframe(monkeypatch):
@@ -33,3 +34,9 @@ def test_generate_sql_results_handles_non_dataframe(monkeypatch):
     sql, df, resp = asyncio.run(chat.generate_sql_results("sess", "schema", "question"))
     assert df.empty
     assert list(df.columns) == []
+
+
+def test_default_pipeline_uses_local_chat_model():
+    assert chat._DEFAULT_PIPELINE_ARGS["SQLBuilder_model"] == CHAT_MODEL
+    assert chat._DEFAULT_PIPELINE_ARGS["SQLChecker_model"] == CHAT_MODEL
+    assert chat._DEFAULT_PIPELINE_ARGS["SQLDebugger_model"] == CHAT_MODEL


### PR DESCRIPTION
## Summary
- update the chat service defaults to reuse the configured local chat model instead of hard-coded Gemini models
- add a regression test to ensure the chat service pipeline arguments track the configured model value

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9efba0288832dbc29ffe424539d08