### PR TITLE
Offload synchronous chat helpers to background threads

### DIFF
--- a/dbconnectors/LocalPgConnector.py
+++ b/dbconnectors/LocalPgConnector.py
@@ -623,24 +623,29 @@ class LocalPgConnector(DBConnector, ABC):
     async def getSimilarMatches(self, mode, user_grouping, qe, num_matches, similarity_threshold):
 
         print("localPGConnector getSimilarMatches")
+        match_list = await asyncio.to_thread(
+            self.retrieve_matches,
+            mode,
+            user_grouping,
+            qe,
+            similarity_threshold,
+            num_matches,
+        )
         if mode == 'table':
             print("localPGConnector getSimilarMatches table")
-            match_result = self.retrieve_matches(mode, user_grouping, qe, similarity_threshold, num_matches)
-            match_result = match_result[0]
+            match_result = match_list[0] if match_list else ""
 
         elif mode == 'column':
             print("localPGConnector getSimilarMatches Column")
-            match_result = self.retrieve_matches(mode, user_grouping, qe, similarity_threshold, num_matches)
-            match_result = match_result[0]
+            match_result = match_list[0] if match_list else ""
 
         elif mode == 'example':
             print("localPGConnector getSimilarMatches Example")
-            match_result = self.retrieve_matches(mode, user_grouping, qe, similarity_threshold, num_matches)
-            print("localPGConnector getSimilarMatches match_result" , match_result)
-            if len(match_result) == 0:
+            print("localPGConnector getSimilarMatches match_result" , match_list)
+            if not match_list:
                 match_result = None
             else:
-                match_result = match_result[0]
+                match_result = match_list[0]
 
         return match_result
 

--- a/services/omop_concept_chat.py
+++ b/services/omop_concept_chat.py
@@ -202,9 +202,9 @@ async def run(
     """Generate an OMOP concept chat response enriched with retrieved concepts."""
 
     embedder = _get_embedder()
-    raw_embedding = embedder.create(question)
+    raw_embedding = await asyncio.to_thread(embedder.create, question)
     query_embedding = _extract_embedding(raw_embedding)
-    concepts = _query_similar_concepts(query_embedding, limit=top_k)
+    concepts = await asyncio.to_thread(_query_similar_concepts, query_embedding, top_k)
 
     prompt_template = PROMPTS["omop_concept_chat"]
     base_prompt = format_prompt(prompt_template, question=question)


### PR DESCRIPTION
## Summary
- offload history loading, paper embedding, callback posts, and chat persistence in the Flask chat handler via `asyncio.to_thread`
- wrap OMOP concept embedding and SQL pipeline helpers in background threads so synchronous model, database, and logging calls no longer block the event loop
- update the local pgvector connector to fetch similar matches through `asyncio.to_thread`, ensuring vector lookups yield control back to asyncio

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68da18bc47c0832d9ae862e73192aa68